### PR TITLE
Update API URL

### DIFF
--- a/kmoni.go
+++ b/kmoni.go
@@ -42,5 +42,5 @@ func jst() *time.Location {
 
 func url(hypo string, t time.Time) string {
 	s := t.In(jst()).Format("20060102150405")
-	return fmt.Sprintf("http://www.kmoni.bosai.go.jp/new/webservice/hypo/%s/%s.json", hypo, s)
+	return fmt.Sprintf("http://www.kmoni.bosai.go.jp/webservice/hypo/%s/%s.json", hypo, s)
 }


### PR DESCRIPTION
こんにちは。いつも便利に使わせてもらっております。
本日、`/new/`の付いているURLが廃止になり、動かなくなっていたため、APIのURLを更新しました。

> 現在、強震モニタへはいくつかのURLからアクセスすることが出来ますが、
> 今後は http://www.kmoni.bosai.go.jp/ をご利用いただきますようお願いいたします。
>
> 現在アクセス可能な http://realtime-earthquake-monitor.bosai.go.jp/
> 、 http://www.kmoni.bosai.go.jp/new/ 、および関連する/new/の付いたURLに関しては
> 2019年10月1日をもって廃止いたしますので、あらかじめご了承ください。

引用元: http://www.kyoshin.bosai.go.jp/cgi-bin/kyoshin/news/newnews.cgi?20190924133000.new+J

よろしくお願いします。